### PR TITLE
feat: add ts-json-schema-generator options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,18 @@ Install with [npm](https://www.npmjs.com/):
     Options
       --watch               [Boolean] If set the flag, start watch mode
       --check               [Boolean] If set the flag, start test mode
-      --tsconfigFilePath    [Path:String] path to tsconfig.json
       --cwd                 [Path:String] current working directory
+      --tsconfigFilePath    [Path:String] path to tsconfig.json
       --generatorScript     [Path:String] A JavaScript file path that customize validator code generator
       --verbose             [Boolean] If set the flag, show progressing logs
+     
+      ts-json-schema-generator options
+      --sortProps               [Boolean] 
+      --strictTuples            [Boolean] 
+      --encodeRefs              [Boolean] 
+      --skipTypeCheck           [Boolean] true by default
+      --additionalProperties    [Boolean] false by default
+    
 
     Examples
       $ create-validator-ts "src/**/api-types.ts"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Install with [npm](https://www.npmjs.com/):
 
 ## Usage
 
+
     Usage
       $ create-validator-ts [file|glob*]
  
@@ -42,11 +43,16 @@ Install with [npm](https://www.npmjs.com/):
       --verbose             [Boolean] If set the flag, show progressing logs
      
       ts-json-schema-generator options
-      --sortProps               [Boolean] 
-      --strictTuples            [Boolean] 
-      --encodeRefs              [Boolean] 
-      --skipTypeCheck           [Boolean] true by default
-      --additionalProperties    [Boolean] false by default
+      --sortProps               [Boolean] Enable sortProps
+      --no-sortProps            
+      --strictTuples            [Boolean] Enable strictTuples
+      --no-strictTuples         
+      --encodeRefs              [Boolean] Enable encodeRefs
+      --no-encodeRefs           
+      --skipTypeCheck           [Boolean] Enable skipTypeCheck. true by default
+      --no-skipTypeCheck
+      --additionalProperties    [Boolean] Enable additionalProperties. false by default
+      --no-additionalProperties 
     
 
     Examples

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,10 +10,18 @@ export const cli = meow(
     Options
       --watch               [Boolean] If set the flag, start watch mode
       --check               [Boolean] If set the flag, start test mode
-      --tsconfigFilePath    [Path:String] path to tsconfig.json
       --cwd                 [Path:String] current working directory
+      --tsconfigFilePath    [Path:String] path to tsconfig.json
       --generatorScript     [Path:String] A JavaScript file path that customize validator code generator
       --verbose             [Boolean] If set the flag, show progressing logs
+     
+      ts-json-schema-generator options
+      --sortProps               [Boolean] 
+      --strictTuples            [Boolean] 
+      --encodeRefs              [Boolean] 
+      --skipTypeCheck           [Boolean] true by default
+      --additionalProperties    [Boolean] false by default
+    
 
     Examples
       $ create-validator-ts "src/**/api-types.ts"
@@ -45,6 +53,21 @@ export const cli = meow(
             verbose: {
                 type: "boolean",
                 default: true
+            },
+            sortProps: {
+                type: "boolean"
+            },
+            strictTuples: {
+                type: "boolean"
+            },
+            skipTypeCheck: {
+                type: "boolean"
+            },
+            encodeRefs: {
+                type: "boolean"
+            },
+            additionalProperties: {
+                type: "boolean"
             }
         },
         autoHelp: true,
@@ -56,30 +79,24 @@ export const run = async (
     input = cli.input,
     flags = cli.flags
 ): Promise<{ exitStatus: number; stdout: string | null; stderr: Error | null }> => {
+    const options = {
+        cwd: flags.cwd,
+        verbose: flags.verbose,
+        targetGlobs: input,
+        codeGeneratorScript: flags.generatorScript,
+        tsconfigFilePath: flags.tsconfigFilePath,
+        sortProps: flags.sortProps,
+        strictTuples: flags.strictTuples,
+        skipTypeCheck: flags.skipTypeCheck,
+        encodeRefs: flags.encodeRefs,
+        additionalProperties: flags.additionalProperties
+    };
     if (flags.check) {
-        await testGeneratedValidator({
-            cwd: flags.cwd,
-            verbose: flags.verbose,
-            targetGlobs: input,
-            codeGeneratorScript: flags.generatorScript,
-            tsconfigFilePath: flags.tsconfigFilePath
-        });
+        await testGeneratedValidator(options);
     } else if (flags.watch) {
-        await watchValidator({
-            cwd: flags.cwd,
-            verbose: flags.verbose,
-            targetGlobs: input,
-            codeGeneratorScript: flags.generatorScript,
-            tsconfigFilePath: flags.tsconfigFilePath
-        });
+        await watchValidator(options);
     } else {
-        await createValidator({
-            cwd: flags.cwd,
-            verbose: flags.verbose,
-            targetGlobs: input,
-            codeGeneratorScript: flags.generatorScript,
-            tsconfigFilePath: flags.tsconfigFilePath
-        });
+        await createValidator(options);
     }
     return {
         stdout: null,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,11 +16,16 @@ export const cli = meow(
       --verbose             [Boolean] If set the flag, show progressing logs
      
       ts-json-schema-generator options
-      --sortProps               [Boolean] 
-      --strictTuples            [Boolean] 
-      --encodeRefs              [Boolean] 
-      --skipTypeCheck           [Boolean] true by default
-      --additionalProperties    [Boolean] false by default
+      --sortProps               [Boolean] Enable sortProps
+      --no-sortProps            
+      --strictTuples            [Boolean] Enable strictTuples
+      --no-strictTuples         
+      --encodeRefs              [Boolean] Enable encodeRefs
+      --no-encodeRefs           
+      --skipTypeCheck           [Boolean] Enable skipTypeCheck. true by default
+      --no-skipTypeCheck
+      --additionalProperties    [Boolean] Enable additionalProperties. false by default
+      --no-additionalProperties 
     
 
     Examples

--- a/src/create-validator-ts.ts
+++ b/src/create-validator-ts.ts
@@ -5,19 +5,41 @@ import { CodeGenerator } from "./default-code-generator";
 
 const fs = _fs.promises;
 
+export type TsJsonSchemaGeneratorOptions = {
+    // ts-json-schema-generator Options
+    // https://github.com/vega/ts-json-schema-generator/blob/80bba1cb2b893edc81fce08accddae76390d5156/src/Config.ts#L1-L15
+    extraTags?: string[];
+    sortProps?: boolean;
+    strictTuples?: boolean;
+    encodeRefs?: boolean;
+    /**
+     * true by default
+     */
+    skipTypeCheck?: boolean;
+    /**
+     * false by default
+     */
+    additionalProperties?: boolean;
+};
+export type GeneratorValidatorOptions = {
+    cwd: string;
+    validatorGenerator: CodeGenerator;
+    tsconfigFilePath: string;
+    filePath: string;
+} & TsJsonSchemaGeneratorOptions;
+
 export async function generateValidator({
     cwd,
     validatorGenerator,
     tsconfigFilePath,
     filePath,
-    extraTags = []
-}: {
-    cwd: string;
-    validatorGenerator: CodeGenerator;
-    tsconfigFilePath: string;
-    filePath: string;
-    extraTags?: string[];
-}) {
+    extraTags = [],
+    sortProps,
+    strictTuples,
+    skipTypeCheck = true,
+    encodeRefs,
+    additionalProperties = false
+}: GeneratorValidatorOptions) {
     const absoluteFilePath = path.resolve(cwd, filePath);
     const parentFileDir = path.dirname(path.resolve(cwd, filePath));
     const fileName = path.basename(absoluteFilePath, ".ts");
@@ -27,8 +49,11 @@ export async function generateValidator({
             path: absoluteFilePath,
             tsconfig: tsconfigFilePath,
             type: "*",
-            skipTypeCheck: true,
-            additionalProperties: false,
+            skipTypeCheck: skipTypeCheck ?? true,
+            additionalProperties: additionalProperties ?? false,
+            sortProps: sortProps,
+            strictTuples: strictTuples,
+            encodeRefs: encodeRefs,
             extraTags: extraTags
         };
         const generator = createGenerator(config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import globWatch from "glob-watcher";
 import _fs from "fs";
 import * as globby from "globby";
 import assert from "assert";
-import { generateValidator } from "./create-validator-ts";
+import { generateValidator, TsJsonSchemaGeneratorOptions } from "./create-validator-ts";
 import { CodeGenerator } from "./default-code-generator";
 import path from "path";
 
@@ -15,7 +15,7 @@ export type CreateTSValidatorOptions = {
     tsconfigFilePath: string;
     codeGeneratorScript: string;
     targetGlobs: string[];
-};
+} & TsJsonSchemaGeneratorOptions;
 
 export async function watchValidator(options: CreateTSValidatorOptions) {
     const { generator, generatorOptions = {} } = (await import(
@@ -29,6 +29,7 @@ export async function watchValidator(options: CreateTSValidatorOptions) {
     const watcher = globWatch(options.targetGlobs, {
         ignoreInitial: true
     });
+    const { sortProps, strictTuples, encodeRefs, skipTypeCheck, additionalProperties } = options;
     return new Promise<void>((resolve, reject) => {
         watcher.on("change", async (filePath) => {
             const result = await generateValidator({
@@ -36,7 +37,12 @@ export async function watchValidator(options: CreateTSValidatorOptions) {
                 filePath: filePath,
                 tsconfigFilePath: options.tsconfigFilePath,
                 validatorGenerator: generator,
-                extraTags: generatorOptions.extraTags || []
+                extraTags: generatorOptions.extraTags || [],
+                sortProps,
+                strictTuples,
+                encodeRefs,
+                skipTypeCheck,
+                additionalProperties
             });
             if (!result) {
                 return;
@@ -69,6 +75,7 @@ export async function testGeneratedValidator(options: CreateTSValidatorOptions) 
             extraTags?: string[];
         };
     };
+    const { sortProps, strictTuples, encodeRefs, skipTypeCheck, additionalProperties } = options;
     return Promise.all(
         files.map(async (filePath) => {
             const result = await generateValidator({
@@ -76,7 +83,12 @@ export async function testGeneratedValidator(options: CreateTSValidatorOptions) 
                 filePath: filePath,
                 tsconfigFilePath: options.tsconfigFilePath,
                 validatorGenerator: generator,
-                extraTags: generatorOptions.extraTags || []
+                extraTags: generatorOptions.extraTags || [],
+                sortProps,
+                strictTuples,
+                encodeRefs,
+                skipTypeCheck,
+                additionalProperties
             });
             if (!result) {
                 return;
@@ -116,6 +128,7 @@ export async function createValidator(options: CreateTSValidatorOptions) {
         cwd: options.cwd,
         absolute: true
     });
+    const { sortProps, strictTuples, encodeRefs, skipTypeCheck, additionalProperties } = options;
     return Promise.all(
         files.map(async (filePath) => {
             const result = await generateValidator({
@@ -123,7 +136,12 @@ export async function createValidator(options: CreateTSValidatorOptions) {
                 filePath: filePath,
                 tsconfigFilePath: options.tsconfigFilePath,
                 validatorGenerator: generator,
-                extraTags: generatorOptions.extraTags || []
+                extraTags: generatorOptions.extraTags || [],
+                sortProps,
+                strictTuples,
+                encodeRefs,
+                skipTypeCheck,
+                additionalProperties
             });
             if (!result) {
                 return;

--- a/test/snapshots/valid/api-types.validator.ts
+++ b/test/snapshots/valid/api-types.validator.ts
@@ -16,7 +16,8 @@ export const SCHEMA = {
             },
             "required": [
                 "id"
-            ]
+            ],
+            "additionalProperties": false
         },
         "GetAPIResponseBody": {
             "type": "object",
@@ -27,7 +28,8 @@ export const SCHEMA = {
             },
             "required": [
                 "ok"
-            ]
+            ],
+            "additionalProperties": false
         }
     }
 };

--- a/test/snapshots/valid/api-types.validator.ts
+++ b/test/snapshots/valid/api-types.validator.ts
@@ -16,8 +16,7 @@ export const SCHEMA = {
             },
             "required": [
                 "id"
-            ],
-            "additionalProperties": false
+            ]
         },
         "GetAPIResponseBody": {
             "type": "object",
@@ -28,8 +27,7 @@ export const SCHEMA = {
             },
             "required": [
                 "ok"
-            ],
-            "additionalProperties": false
+            ]
         }
     }
 };


### PR DESCRIPTION
```
    Usage
      $ create-validator-ts [file|glob*]
 
    Options
      --watch               [Boolean] If set the flag, start watch mode
      --check               [Boolean] If set the flag, start test mode
      --cwd                 [Path:String] current working directory
      --tsconfigFilePath    [Path:String] path to tsconfig.json
      --generatorScript     [Path:String] A JavaScript file path that customize validator code generator
      --verbose             [Boolean] If set the flag, show progressing logs
     
      ts-json-schema-generator options
      --sortProps               [Boolean] 
      --strictTuples            [Boolean] 
      --encodeRefs              [Boolean] 
      --skipTypeCheck           [Boolean] true by default
      --additionalProperties    [Boolean] false by default
    

    Examples
      $ create-validator-ts "src/**/api-types.ts"
      # custom tsconfig.json
      $ create-validator-ts "src/**/api-types.ts" --tsconfigFilePath ./tsconfig.app.json
      # custom validator code
      $ create-validator-ts "src/**/api-types.ts" --generatorScript ./custom.js
```

fix #12 