### PR TITLE
fix: add default to skipTypeCheck option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,7 +77,8 @@ export const cli = meow(
                 type: "boolean"
             },
             skipTypeCheck: {
-                type: "boolean"
+                type: "boolean",
+                default: true
             },
             encodeRefs: {
                 type: "boolean"


### PR DESCRIPTION
## Problem
- The `skipTypeCheck` option in the CLI was not behaving as documented.
- The help text states that `skipTypeCheck` is `true` by default, but the actual implementation was missing the `default: true` configuration in the meow flags setup, causing the option to default to `false` when not specified.

## Solution
- Added `default: true` to the `skipTypeCheck` flag configuration to align the actual behavior with the documented behavior.